### PR TITLE
Allowed deployments to ref and int

### DIFF
--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -49,24 +49,23 @@ extends:
         proxy_path: sandbox
         post_deploy:
           - template: ./templates/run-tests.yml
-    #   - environment: ref
-    #     depends_on:
-    #       - internal_qa
-    #       - internal_qa_sandbox
-    #     post_deploy:
-    #       - template: ./templates/run-tests.yml
+      - environment: ref
+        depends_on:
+          - internal_qa
+          - internal_qa_sandbox
+        post_deploy:
+          - template: ./templates/run-tests.yml
       - environment: sandbox
         proxy_path: sandbox
         post_deploy:
           - template: ./templates/run-tests.yml
-    # # Enable int environment when ready by uncommenting:
-    #   - environment: int
-    #     depends_on:
-    #       - internal_qa
-    #       - internal_qa_sandbox
-    #     post_deploy:
-    #       - template: ./templates/run-tests.yml
-    #         parameters:
-    #           full: true
-    #           test-command: prod
-    #           smoketest-command: prod
+      - environment: int
+        depends_on:
+          - internal_qa
+          - internal_qa_sandbox
+        post_deploy:
+          - template: ./templates/run-tests.yml
+            parameters:
+              full: true
+              test-command: prod
+              smoketest-command: prod

--- a/manifest_template.yml
+++ b/manifest_template.yml
@@ -11,7 +11,6 @@ APIGEE_ENVIRONMENTS:
   - name: ref
     display_name: Reference
     has_mock_auth: true
-# Enable environments when ready by uncommenting:
   - name: internal-dev-sandbox
     display_name: Internal Development Sandbox
     portal_visibility: false
@@ -25,8 +24,8 @@ APIGEE_ENVIRONMENTS:
   - name: sandbox
     display_name: Sandbox
     portal_visibility: true
-  # - name: int
-  #   display_name: Integration Testing
+  - name: int
+    display_name: Integration Testing
 ---
 meta:
   api:


### PR DESCRIPTION
## Summary
* Routine Change

https://nhsd-jira.digital.nhs.uk/browse/EM-330

https://nhsd-confluence.digital.nhs.uk/display/APM/Creating+an+API+specification+page+in+production+Bloomreach+CMS#CreatinganAPIspecificationpageinproductionBloomreachCMS-obtain-specification-id-from-prod-apigee refer to steps 1 and 2. In order to get our specs published in prod bloomreach and the API catalogue we need to deploy to INT. (And then get help from APIGee to find our deployed spec ID).