### PR TITLE
[NOJIRA] Allowed the correlation id header

### DIFF
--- a/proxies/sandbox/apiproxy/policies/AssignMessage.AddCors.xml
+++ b/proxies/sandbox/apiproxy/policies/AssignMessage.AddCors.xml
@@ -4,9 +4,7 @@
     <Set>
         <Headers>
             <Header name="Access-Control-Allow-Origin">{request.header.origin}</Header>
-            <Header name="Access-Control-Allow-Headers">origin, x-requested-with, accept, content-type, nhsd-session-urid</Header>
-            <!--you can add headers here if you want to expose
-            <Header name="Access-Control-Expose-Headers">origin, x-requested-with, accept, content-type, nhsd-session-urid, x-my-new-header</Header> -->
+            <Header name="Access-Control-Allow-Headers">origin, x-requested-with, accept, content-type, nhsd-session-urid, x-correlation-id</Header>
             <Header name="Access-Control-Max-Age">3628800</Header>
             <Header name="Access-Control-Allow-Methods">GET, PUT, POST, DELETE</Header>
         </Headers>


### PR DESCRIPTION
## Summary
* Bugfix

Since our last spec updates (including the x-correlation-id header), our Sandbox no longer works on the catalogue page as CORS does not allow that header. Goodness knows why as it's a standard APIM header. Anyway, here's the fix.

## Reviews Required
* [ ] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
