### PR TITLE
[EM-492] Point status endpoint at MNS backend

### DIFF
--- a/proxies/live/apiproxy/policies/ServiceCallout.CallHealthcheckEndpoint.xml
+++ b/proxies/live/apiproxy/policies/ServiceCallout.CallHealthcheckEndpoint.xml
@@ -3,6 +3,11 @@
     <DisplayName>ServiceCallout.CallHealthcheckEndpoint</DisplayName>
     <Properties/>
     <Request clearPayload="true" variable="healthcheckRequest">
+        <Set>
+            <Headers>
+                <Header name="User-Agent">{request.header.user-agent}</Header>
+            </Headers>
+        </Set>
         <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
     </Request>
     <Response>healthcheckResponse</Response>

--- a/proxies/live/apiproxy/policies/ServiceCallout.CallHealthcheckEndpoint.xml
+++ b/proxies/live/apiproxy/policies/ServiceCallout.CallHealthcheckEndpoint.xml
@@ -6,22 +6,14 @@
         <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
     </Request>
     <Response>healthcheckResponse</Response>
-<!--    <HTTPTargetConnection>-->
-<!--        <SSLInfo>-->
-<!--            <Enabled>true</Enabled>-->
-<!--        </SSLInfo>-->
-<!--        <LoadBalancer>-->
-<!--            <Server name="multicast-notification-service" />-->
-<!--        </LoadBalancer>-->
-<!--        <Path>/_ping</Path>-->
-<!--    </HTTPTargetConnection>-->
     <HTTPTargetConnection>
-        <URL>http://mocktarget.apigee.net</URL>
-        <Properties>
-            <Property name="supports.http10">true</Property>
-            <Property name="request.retain.headers">User-Agent,Referer,Accept-Language</Property>
-            <Property name="retain.queryparams">apikey</Property>
-        </Properties>
+        <SSLInfo>
+            <Enabled>true</Enabled>
+        </SSLInfo>
+        <LoadBalancer>
+            <Server name="multicast-notification-service" />
+        </LoadBalancer>
+        <Path>/_ping</Path>
     </HTTPTargetConnection>
     <Timeout>20000</Timeout>
 </ServiceCallout>

--- a/proxies/live/apiproxy/policies/ServiceCallout.CallHealthcheckEndpoint.xml
+++ b/proxies/live/apiproxy/policies/ServiceCallout.CallHealthcheckEndpoint.xml
@@ -3,6 +3,11 @@
     <DisplayName>ServiceCallout.CallHealthcheckEndpoint</DisplayName>
     <Properties/>
     <Request clearPayload="true" variable="healthcheckRequest">
+        <Set>
+            <Headers>
+                <Header name="User-Agent">{request.header.user-agent}</Header>
+            </Headers>
+        </Set>
         <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
     </Request>
     <Response>healthcheckResponse</Response>
@@ -14,11 +19,6 @@
             <Server name="multicast-notification-service" />
         </LoadBalancer>
         <Path>/_ping</Path>
-        <Properties>
-            <Property name="supports.http10">true</Property>
-            <Property name="request.retain.headers">User-Agent,Referer,Accept-Language</Property>
-            <Property name="retain.queryparams">apikey</Property>
-        </Properties>
     </HTTPTargetConnection>
     <Timeout>20000</Timeout>
 </ServiceCallout>

--- a/proxies/live/apiproxy/policies/ServiceCallout.CallHealthcheckEndpoint.xml
+++ b/proxies/live/apiproxy/policies/ServiceCallout.CallHealthcheckEndpoint.xml
@@ -3,11 +3,6 @@
     <DisplayName>ServiceCallout.CallHealthcheckEndpoint</DisplayName>
     <Properties/>
     <Request clearPayload="true" variable="healthcheckRequest">
-        <Set>
-            <Headers>
-                <Header name="User-Agent">{request.header.user-agent}</Header>
-            </Headers>
-        </Set>
         <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
     </Request>
     <Response>healthcheckResponse</Response>
@@ -19,6 +14,11 @@
             <Server name="multicast-notification-service" />
         </LoadBalancer>
         <Path>/_ping</Path>
+        <Properties>
+            <Property name="supports.http10">true</Property>
+            <Property name="request.retain.headers">User-Agent,Referer,Accept-Language</Property>
+            <Property name="retain.queryparams">apikey</Property>
+        </Properties>
     </HTTPTargetConnection>
     <Timeout>20000</Timeout>
 </ServiceCallout>

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -56,6 +56,18 @@ def test_wait_for_ping(nhsd_apim_proxy_url):
 
 
 @pytest.mark.smoketest
+def test_status(nhsd_apim_proxy_url, status_endpoint_auth_headers):
+    resp = requests.get(
+        f"{nhsd_apim_proxy_url}/_status", headers=status_endpoint_auth_headers
+    )
+    resp_content = resp.json()
+
+    assert resp.status_code == 200
+    assert resp_content.get("commitId") == getenv('SOURCE_COMMIT_ID')
+    assert resp_content.get("status") == "pass"
+
+
+@pytest.mark.smoketest
 def test_wait_for_status(nhsd_apim_proxy_url, status_endpoint_auth_headers):
     retries = 0
     resp = requests.get(f"{nhsd_apim_proxy_url}/_status", headers=status_endpoint_auth_headers)
@@ -77,18 +89,6 @@ def test_wait_for_status(nhsd_apim_proxy_url, status_endpoint_auth_headers):
         pytest.fail("version not found")
 
     assert deployed_commit_id == getenv('SOURCE_COMMIT_ID')
-
-
-@pytest.mark.smoketest
-def test_status(nhsd_apim_proxy_url, status_endpoint_auth_headers):
-    resp = requests.get(
-        f"{nhsd_apim_proxy_url}/_status", headers=status_endpoint_auth_headers
-    )
-    resp_content = resp.json()
-
-    assert resp.status_code == 200
-    assert resp_content.get("commitId") == getenv('SOURCE_COMMIT_ID')
-    assert resp_content.get("status") == "pass"
 
 
 @pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level0"})

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -63,7 +63,11 @@ def test_status(nhsd_apim_proxy_url, status_endpoint_auth_headers):
     resp_content = resp.json()
 
     assert resp.status_code == 200
+
     assert resp_content.get("commitId") == getenv('SOURCE_COMMIT_ID')
+    assert resp_content.get("status") == "pass"
+    assert resp_content["checks"]["healthcheck"]["outcome"] == {"status": "pass"}
+    assert resp_content["checks"]["healthcheck"]["timeout"] == "false"
 
 
 @pytest.mark.smoketest

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -63,11 +63,8 @@ def test_status(nhsd_apim_proxy_url, status_endpoint_auth_headers):
     resp_content = resp.json()
 
     assert resp.status_code == 200
-
     assert resp_content.get("commitId") == getenv('SOURCE_COMMIT_ID')
     assert resp_content.get("status") == "pass"
-    assert resp_content["checks"]["healthcheck"]["outcome"] == {"status": "pass"}
-    assert resp_content["checks"]["healthcheck"]["timeout"] == "false"
 
 
 @pytest.mark.smoketest

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -56,18 +56,6 @@ def test_wait_for_ping(nhsd_apim_proxy_url):
 
 
 @pytest.mark.smoketest
-def test_status(nhsd_apim_proxy_url, status_endpoint_auth_headers):
-    resp = requests.get(
-        f"{nhsd_apim_proxy_url}/_status", headers=status_endpoint_auth_headers
-    )
-    resp_content = resp.json()
-
-    assert resp.status_code == 200
-    assert resp_content.get("commitId") == getenv('SOURCE_COMMIT_ID')
-    assert resp_content.get("status") == "pass"
-
-
-@pytest.mark.smoketest
 def test_wait_for_status(nhsd_apim_proxy_url, status_endpoint_auth_headers):
     retries = 0
     resp = requests.get(f"{nhsd_apim_proxy_url}/_status", headers=status_endpoint_auth_headers)
@@ -89,6 +77,18 @@ def test_wait_for_status(nhsd_apim_proxy_url, status_endpoint_auth_headers):
         pytest.fail("version not found")
 
     assert deployed_commit_id == getenv('SOURCE_COMMIT_ID')
+
+
+@pytest.mark.smoketest
+def test_status(nhsd_apim_proxy_url, status_endpoint_auth_headers):
+    resp = requests.get(
+        f"{nhsd_apim_proxy_url}/_status", headers=status_endpoint_auth_headers
+    )
+    resp_content = resp.json()
+
+    assert resp.status_code == 200
+    assert resp_content.get("commitId") == getenv('SOURCE_COMMIT_ID')
+    assert resp_content.get("status") == "pass"
 
 
 @pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level0"})


### PR DESCRIPTION
## Summary
* Routine Change

Updates the Apigee proxy so it will point at the MNS _ping endpoint when status is called, as advised by https://nhsd-confluence.digital.nhs.uk/pages/viewpage.action?spaceKey=APM&title=_status+endpoint

Ultimately I had to specifically tell the Callout flow to add the client's user-agent header. It would have been nicer to use the <Properties/> to retain all headers as it used to, but I tested and this only seems to work when you set the target as a URL. We are using target servers in a <LoadBalancer> configuration as that's the way it's set up with the infrastructure repo - target servers, SSL secret store and so on.

I have also slightly tightened up the endpoint tests to make an extra assertions during the status checks. See proxies/live/apiproxy/resources/jsc/HealthCheck.SetResponse.js for the APIM-implemented logic for how the status returned by our endpoint is modified before being passed to the client.


## Reviews Required
* [ ] Dev


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [x] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
