### PR TITLE
Added NHS Identity UUID (application ID in our case) to the headers

### DIFF
--- a/proxies/live/apiproxy/policies/AssignMessage.AddApplicationHeaders.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.AddApplicationHeaders.xml
@@ -1,0 +1,10 @@
+<AssignMessage async="false" continueOnError="false" enabled="true" name="AssignMessage.AddApplicationHeaders">
+  <Add>
+      <Headers>
+          <Header name="X-MNS-Application-ID">{developer.app.id}</Header>
+          <Header name="X-MNS-Application-Name">{developer.app.name}</Header>
+      </Headers>
+  </Add>
+  <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+  <AssignTo createNew="false" transport="http" type="request"/>
+</AssignMessage>

--- a/proxies/live/apiproxy/policies/AssignMessage.AddUserIdHeader.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.AddUserIdHeader.xml
@@ -1,7 +1,8 @@
 <AssignMessage async="false" continueOnError="false" enabled="true" name="AssignMessage.AddUserIdHeader">
   <Add>
       <Headers>
-          <Header name="NHSE-Identity-UUID">{accesstoken.id_token}</Header>
+          <Header name="NHSE-Identity-UUID">{developer.app.id}</Header>
+          <Header name="Testing-Header-Forwarding">{developer.app.name}</Header>
       </Headers>
   </Add>
   <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>

--- a/proxies/live/apiproxy/policies/AssignMessage.AddUserIdHeader.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.AddUserIdHeader.xml
@@ -1,7 +1,7 @@
 <AssignMessage async="false" continueOnError="false" enabled="true" name="AssignMessage.AddUserIdHeader">
   <Add>
       <Headers>
-          <Header name="NHSD-Identity-UUID">{accesstoken.id_token-subject}</Header>
+          <Header name="NHSE-Identity-UUID">{accesstoken.id_token-subject}</Header>
       </Headers>
   </Add>
   <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>

--- a/proxies/live/apiproxy/policies/AssignMessage.AddUserIdHeader.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.AddUserIdHeader.xml
@@ -1,7 +1,7 @@
 <AssignMessage async="false" continueOnError="false" enabled="true" name="AssignMessage.AddUserIdHeader">
   <Add>
       <Headers>
-          <Header name="NHSE-Identity-UUID">{accesstoken.id_token-subject}</Header>
+          <Header name="NHSE-Identity-UUID">{accesstoken.id_token}</Header>
       </Headers>
   </Add>
   <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>

--- a/proxies/live/apiproxy/policies/AssignMessage.AddUserIdHeader.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.AddUserIdHeader.xml
@@ -1,9 +1,7 @@
 <AssignMessage async="false" continueOnError="false" enabled="true" name="AssignMessage.AddUserIdHeader">
   <Add>
       <Headers>
-          <Header name="NHSE-Identity-UUID">{developer.app.id}</Header>
-          <Header name="Testing-Header-Forwarding">{developer.app.name}</Header>
-          <Header name="Testing-One-MOre">{accesstoken.auth_user_id}</Header>
+          <Header name="NHSD-Identity-UUID">{accesstoken.id_token-subject}</Header>
       </Headers>
   </Add>
   <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>

--- a/proxies/live/apiproxy/policies/AssignMessage.AddUserIdHeader.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.AddUserIdHeader.xml
@@ -3,6 +3,7 @@
       <Headers>
           <Header name="NHSE-Identity-UUID">{developer.app.id}</Header>
           <Header name="Testing-Header-Forwarding">{developer.app.name}</Header>
+          <Header name="Testing-One-MOre">{accesstoken.auth_user_id}</Header>
       </Headers>
   </Add>
   <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>

--- a/proxies/live/apiproxy/targets/target.xml
+++ b/proxies/live/apiproxy/targets/target.xml
@@ -8,7 +8,7 @@
         <Name>FlowCallout.ApplyRateLimiting</Name>
       </Step>
       <Step>
-        <Name>AssignMessage.AddUserIdHeader</Name>
+        <Name>AssignMessage.AddApplicationHeaders</Name>
       </Step>
     </Request>
   </PreFlow>

--- a/proxies/live/apiproxy/targets/target.xml
+++ b/proxies/live/apiproxy/targets/target.xml
@@ -7,6 +7,9 @@
       <Step>
         <Name>FlowCallout.ApplyRateLimiting</Name>
       </Step>
+      <Step>
+        <Name>AssignMessage.AddUserIdHeader</Name>
+      </Step>
     </Request>
   </PreFlow>
   <FaultRules>


### PR DESCRIPTION
## Summary
* :sparkles: New Feature

As part of the authorisation work, the proxy needs to forward the application ID to the backend so our AWS API Gateway authoriser can process it.

As per APIM guidance - "Where more complex security (fine grained) is required, the preferred pattern is for your API backend to implement that logic (e.g. only Doctors can update the record)" - I would suggest we do the authorisation in the backend.

Ended up not being the id_token-subject that is used. Instead we are forwarding the developer app ID and app Name to the backend: https://nhsd-confluence.digital.nhs.uk/display/APM/Passing+information+to+your+API+backend

Passing on the token is not as useful, as the only app specific data it contains is the API Key. See smoketests/auth_utils/generate_token.py in our backend repo for what is contained in the JWT that gets exchanged for an OAuth token. Essentially, the APIGEE auth server will handle the authentication and only allow the request to proceed if the client provides correct credentials. Only then is the developer app ID surfaced, so when this is passed to the backend we can be sure that this message was originated by the app ID in question.

**Please** could the reviewer sense check the rest of the ticket also makes sense from an authz perspective, as this is the first in quite a few series of steps that need to be done for this feature.

Headers were sent during tests:
![image](https://github.com/NHSDigital/multicast-notification-service/assets/90058721/c116c330-e919-4d9e-8045-67f8bd86289f)


## Reviews Required
* [ ] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [x] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
