### PR TITLE
Removed app ids from test suite

### DIFF
--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -35,7 +35,6 @@ extends:
         post_deploy:
           - template: ./templates/run-tests.yml
             parameters:
-              app_id: "73ee66da-247c-49be-8822-d23aaf4823ec"
               full: true
       - environment: internal-dev-sandbox
         proxy_path: sandbox
@@ -45,7 +44,6 @@ extends:
         post_deploy:
           # - template: ./templates/run-tests.yml No target endpoint configured for QA. Not required currently.
           #   parameters:
-          #     app_id: "73ee66da-247c-49be-8822-d23aaf4823ec"
           #     full: true
       - environment: internal-qa-sandbox
         proxy_path: sandbox
@@ -59,14 +57,11 @@ extends:
       #     - template: ./templates/run-tests.yml
       - environment: sandbox
         proxy_path: sandbox
-        # post_deploy:
-        #   - template: ./templates/run-tests.yml TODO - EM-299 - is this required for sandbox?
       - environment: int
         depends_on:
           - internal_qa_sandbox
         post_deploy:
           - template: ./templates/run-tests.yml
             parameters:
-              app_id: "0d334714-4548-4cf7-8b7f-ac194f341bc6"
               full: true
               test_command: make test-prod


### PR DESCRIPTION
## Summary
Just a quick test at this point. In preparation for prod I have been reading: https://nhsd-confluence.digital.nhs.uk/display/APM/Test+Utils+2.0%3A+Running+tests and I'm not convinced we need app IDs for the types of tests we're executing. Let's see.

Follow up: okay, it seems I was right. I can't guarantee this will work when we merge it into INT, as the tests run slightly different in environments associated with the prod org (int, sandbox and prod). I.e. we only run test_status rather than any of the functional tests.

I see nothing in the test document above that suggests this will be a problem, so I'd like to merge this and fix forward for the pipeline. INT proxy will be unaffected - this is pipeline stuff only, no functional changes.

## Reviews Required
* [x] Dev


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
