### PR TITLE
EM-494 Updated the default app ID value

### DIFF
--- a/azure/templates/run-tests.yml
+++ b/azure/templates/run-tests.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: app_id
     type: string
-    default: "MY APP ID"
+    default: ""
   - name: full
     type: boolean
     default: false


### PR DESCRIPTION
## Summary
* Routine Change

Had the following error in the pipeline when deploying into INT: https://dev.azure.com/NHSD-APIM/API%20Platform/_build/results?buildId=152015&view=logs&j=79b0683d-872f-5f17-a95a-60db6090ea26&t=8654daba-bd8f-5abe-2ec0-5b72d309eef4

This suggest that if you want to bypass this step, you should leave the value empty. We are only running tests for "test_status". The status endpoint only requires an API Key which is passed to the test suite in the background. However, we do not need a test app for the INT or PROD tests so hopefully this will work.

If it doesn't, I'll just add the entry back for INT. Removing it definitely worked for internal-dev, as they use the on-demand app. However, if this is the case, I'm not sure how we manage this for prod - it's a chicken and egg situation wherein you require an app ID but the environment doesn't yet exist. I have put a note on the checklist to raise it in the first time into prod meeting, as I'm sure there's a standard fix. But hopefully this will just work.


## Reviews Required
* [x] Dev

## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [x] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [x] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [x] I have ensured the changelog has been updated by the submitter, if necessary.
