### PR TITLE
EM-497 Up limits and disable default limits- only one user currently

### DIFF
--- a/manifest_template.yml
+++ b/manifest_template.yml
@@ -53,21 +53,17 @@ apigee:
               {{ NAME }}:
                 quota:
                   enabled: true
-                  limit: 300
+                  limit: 3050
                   interval: 1
                   timeunit: minute
                 spikeArrest:
                   enabled: true
-                  ratelimit: 600pm
+                  ratelimit: 3050pm
               app:
                 quota:
-                  enabled: true
-                  limit: 300
-                  interval: 1
-                  timeunit: minute
+                  enabled: false
                 spikeArrest:
-                  enabled: true
-                  ratelimit: 1200pm
+                  enabled: false
         description: {{ DESCRIPTION }}
         displayName: {{ TITLE }}
         environments: [ {{ ENV.name }} ]

--- a/manifest_template.yml
+++ b/manifest_template.yml
@@ -53,12 +53,12 @@ apigee:
               {{ NAME }}:
                 quota:
                   enabled: true
-                  limit: 3050
+                  limit: 3015
                   interval: 1
                   timeunit: minute
                 spikeArrest:
                   enabled: true
-                  ratelimit: 3050pm
+                  ratelimit: 3015pm
               app:
                 quota:
                   enabled: false


### PR DESCRIPTION
## Summary
* :robot: Operational or Infrastructure Change

Creating this PR to update the rate limits in line with decisions made in https://nhsd-confluence.digital.nhs.uk/display/SPINE/KAD+17+-+APIM+Rate-Limiting+for+Production . Also, the app section just defines a default rate limits for all apps (so publishers in our case) that dont have a defined app level rate limit to our proxy. To set different app limits per app follows a different process. We currently only have one publisher so its hard to defined what a sensible default is so just using the proxy level limits for now.


## Reviews Required
* [x] Dev
* [x] Test
* [x] Tech Author
* [x] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [x] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [x] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [x] I have ensured the changelog has been updated by the submitter, if necessary.
