### PR TITLE
EM-633 Add prod test app ID

### DIFF
--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -73,6 +73,6 @@ extends:
         post_deploy:
           - template: ./templates/run-tests.yml
             parameters:
-              app_id: "TODO - create a test app before merging. Will need manual approval"
+              app_id: "6a91d2a8-069a-4731-9c96-cfcccfab63fa"
               full: true
               test_command: make test-prod

--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -73,6 +73,6 @@ extends:
         post_deploy:
           - template: ./templates/run-tests.yml
             parameters:
-              app_id: "6a91d2a8-069a-4731-9c96-cfcccfab63fa"
+              app_id: "0d334714-4548-4cf7-8b7f-ac194f341bc6"
               full: true
               test_command: make test-prod


### PR DESCRIPTION
## Summary
* Routine Change

As per https://nhsd-confluence.digital.nhs.uk/display/APM/Test+Utils+2.0%3A+Running+tests#TestUtils2.0:Runningtests-Runningtestsagainstnhsd-prodorgenvironments Apigee Prod environments (INT and PROD) require that an app ID must be provided for lightweight smoketests. (Note: we only test the status endpoint. Prod and Int smoketests do not test anything to do with publishing events and so on, as this would be ill-advised).

As discussed with APIM, the app could only be done once we had done our first-time deployment into prod.

This will turn the pipeline green. Can be merged in. I am only waiting on the APIM team to action a request to approve this app for use against MNS. Can then do a manual trigger of the prod pipeline once that is all set up.

**Update:**
Okay, ignore this. The INT Test App is in the prod organisation so apparently we can just reference this, according to the APIM engineer who picked up my request. Would have been good to know this originally, as we were not advised of this during our first time into production meeting.

## Reviews Required
* [x] Dev


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [x] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [x] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [x] I have ensured the changelog has been updated by the submitter, if necessary.
