### PR TITLE
EM-707 Remove confluence link in the /events description

### DIFF
--- a/specification/multicast-notification-service.yaml
+++ b/specification/multicast-notification-service.yaml
@@ -122,7 +122,7 @@ paths:
         ### Overview
         Use this endpoint to publish a patient-related event.
 
-        The signal contains only a minimum dataset based on the recommendations of the CloudEvents specification. See [https://nhsd-confluence.digital.nhs.uk/display/SPINE/Event+Pattern+-+Event+Messages](https://nhsd-confluence.digital.nhs.uk/display/SPINE/Event+Pattern+-+Event+Messages) for more info.
+        The event contains only a minimum dataset based on the recommendations of the [CloudEvents specification](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md).
 
         ### Data and Metadata:
           - Metadata: In the context of an event, metadata refers to the additional information that describes the event and provides context about it. It includes elements such as the family name and date of birth which are primarily for verification. Users must be cautious not to use such metadata to modify a patient's demographic details. Instead, if updates are necessary, users should conduct a full PDS retrieval to ensure accuracy and completeness in their workflows.


### PR DESCRIPTION
## Summary
As per MNS Deep Dive review with snr architects, we should remove the reference to Confluence as this is public-facing documentation. (Although worth noting that our only current event publisher is an internal system - Spine PDS).

Note: I renamed signal to event here, in line with our recently updated project terminology. An event is what is sent by publishers - a signal is what is produced by MNS and sent to subscribers. At the moment, the signal only has one additional field added beyond the current events, but in future other subscribable fields could be added.

## Reviews Required
* [x] Tech Author


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [x] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [x] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [x] I have ensured the changelog has been updated by the submitter, if necessary.
