### PR TITLE
EM-659 Include mns signals in docs

### DIFF
--- a/specification/components/schemas/cloudevents/pdsChangeOfGpEventData.yaml
+++ b/specification/components/schemas/cloudevents/pdsChangeOfGpEventData.yaml
@@ -3,13 +3,14 @@ description: ""
 required:
 - fullUrl
 - provenance
+- registrationEncounterCode
 - versionId
-properties: 
-  versionId: 
+properties:
+  versionId:
     type: "string"
     example: 'W/"2"'
     description: "The versionId/ETAG identifies the version of the resource. The format should be a version identifier enclosed in quotes and preceded by 'W/'."
-  fullUrl: 
+  fullUrl:
     type: "string"
     example: "https://int.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient/9912003888"
     description: "The URL where the subscriber can retrieve the source of truth record for the patient or the full event payload."
@@ -37,16 +38,16 @@ properties:
         type: "string"
         example: "The GP Practice"
         description: "The name of the organisation responsible for the creating the event. This may be an empty string due to publisher data issues."
-      identifier: 
+      identifier:
         type: "object"
         required:
         - "system"
         - "value"
         description: "Must follow this identifier system: https://fhir.nhs.uk/Id/nhsSpineASID and provide the ASID value and name of the system."
-        properties : 
-            system: 
+        properties:
+            system:
               type: "string"
               example: "https://fhir.nhs.uk/Id/nhsSpineASID"
-            value: 
+            value:
               type: "string"
               example: "477121000323"

--- a/specification/components/schemas/cloudevents/pdsChangeOfGpMNSJsonSignal.yaml
+++ b/specification/components/schemas/cloudevents/pdsChangeOfGpMNSJsonSignal.yaml
@@ -1,0 +1,73 @@
+type: "object"
+description: "TODO"
+required:
+  - "id"
+  - "type"
+  - "subject"
+  - "source"
+  - "time"
+properties:
+  id:
+    type: "string"
+    description: "UUID v4 format identifier."
+    example: "236a1d4a-5d69-4fa9-9c7f-e72bf505aa5b"
+  type:
+    type: "string"
+    description: "A unique string representing the event type. For the initial private beta, only `pds-change-of-gp-1` signals can be received."
+  subject:
+    type: "object"
+    required:
+      - "nhsNumber"
+      - "familyName"
+      - "dob"
+      - "age"
+    description: "The NHS patient who is the subject of the signal."
+    properties:
+      nhsNumber:
+        type: "string"
+        description: "NHS Number validated in line with https://www.datadictionary.nhs.uk/attributes/nhs_number.html."
+        example: "9912003888"
+      familyName:
+        type: "string"
+        description: "Last name, capitalised"
+        example: "DAWKINS"
+      dob:
+        type: "string"
+        format: "date"
+        description: "ISO-8601 is the required format. However, due to data quality inconsistencies in demographic records, both 'YYYY' and 'YYYY-MM' formats may also be seen. Refer to the [PDS FHIR API documentation](https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir#get-/Patient) for further clarification on the accepted formats."
+        example: "2017-10-02"
+      age:
+        type: "integer"
+        description: "The age of the patient at the time the Signal is created."
+        example: 6
+  source:
+    type: "object"
+    required:
+      - "name"
+      - "identifier"
+    description: "Organisation responsible for publishing the patient-related signal."
+    properties:
+      name:
+        type: "string"
+        description: "Organisation name"
+        example: "NHS Digital"
+      identifier:
+        type: "object"
+        required:
+          - "system"
+          - "value"
+        description: "Must follow this identifier system: https://fhir.nhs.uk/Id/nhsSpineASID and provide the ASID Code as the value."
+        properties:
+          system:
+            type: "string"
+            example: "https://fhir.nhs.uk/Id/nhsSpineASID"
+          value:
+            type: "string"
+            example: "477121000324"
+  time:
+    type: "string"
+    format: "date-time"
+    description: "The time at which the signal is published. This must be a compliant RFC3339 datetime in line with the FHIR standard for [system instants](https://hl7.org/fhir/R4/datatypes.html#instant). This means it can have seconds or milliseconds precision."
+    example: "2022-04-05T17:31:00.000Z"
+  data:
+    $ref: "pdsChangeOfGpEventData.yaml"

--- a/specification/components/schemas/cloudevents/pdsChangeOfGpMNSJsonSignal.yaml
+++ b/specification/components/schemas/cloudevents/pdsChangeOfGpMNSJsonSignal.yaml
@@ -1,5 +1,5 @@
 type: "object"
-description: "TODO"
+description: "The PDS Change of GP Signal. You will receive this object if you subscribe to `pds-change-of-gp-1` events with an `application/json` format."
 required:
   - "id"
   - "type"

--- a/specification/components/success_responses/createSubscription.yaml
+++ b/specification/components/success_responses/createSubscription.yaml
@@ -1,0 +1,7 @@
+type: object
+description: "Subscription create - successful response"
+properties:
+  id:
+    type: string
+    description: The subscription UUID created by the system
+    example: "236a1d4a-5d69-4fa9-9c7f-e72bf505aa5b"

--- a/specification/multicast-notification-service.yaml
+++ b/specification/multicast-notification-service.yaml
@@ -74,8 +74,8 @@ info:
     | Environment       | Base URL                                                               |
     | ----------------- | ---------------------------------------------------------------------- |
     | Sandbox           | `https://sandbox.api.service.nhs.uk/multicast-notification-service`    |
-    | Integration test  | `https://int.api.service.nhs.uk/multicast-notification-service`                                                     |
-    | Production        | Not yet available                                                      |
+    | Integration test  | `https://int.api.service.nhs.uk/multicast-notification-service`        |
+    | Production        | `https://api.service.nhs.uk/multicast-notification-service`            |
 
     ### Sandbox testing
     Our [sandbox environment](https://digital.nhs.uk/developer/guides-and-documentation/testing#sandbox-testing):
@@ -307,10 +307,17 @@ paths:
           $ref: "components/errors/internal-error.yaml"
   /subscriptions:
     post:
-      summary: "Subscribe to events"
+      summary: "Subscribe to signals"
       description: |
         ### Overview
-        Use this endpoint to subscribe to patient-related signals.
+        Use this endpoint to subscribe to patient-related signals. 
+
+        ### Available signals
+        You can currently subscribe to the following patient-related signals. Browse the additional success responses below to view the schemas for the different MNS signals.
+
+        |  Event Type          | Payload format                                                         |
+        | -------------------- | ---------------------------------------------------------------------- |
+        | `pds-change-of-gp-1` | `application/json` (based on [CloudEvents](https://cloudevents.io/))   |
 
         ### Sandbox testing
         You can test the following scenarios in our sandbox environment:

--- a/specification/multicast-notification-service.yaml
+++ b/specification/multicast-notification-service.yaml
@@ -224,7 +224,7 @@ paths:
                   type: object
                   description: "This field is optional, dependent on the agreements between the publishing system and the MNS team. While the data schema might vary based on the system and use-case, it is preferred to include a pointer for subscribers to access the full record when necessary for their workflow."
                   anyOf:
-                    - $ref: "components/schemas/cloudevents/pdsEventData.yaml"
+                    - $ref: "components/schemas/cloudevents/pdsChangeOfGpEventData.yaml"
             examples:
               pdsChangeOfGpEvent:
                 value:
@@ -405,16 +405,15 @@ paths:
 
       responses:
         201:
-          description: Created - the subscription has been successfully created
+          description: | 
+            Subscription created successfully - see the first example for the response structure. The other examples show the MNS Signals
+            you can receive in your requested endpoint.
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                    description: The subscription UUID created by the system
-                    example: "236a1d4a-5d69-4fa9-9c7f-e72bf505aa5b"
+                oneOf:
+                  - $ref: "components/schemas/cloudevents/pdsChangeOfGpMNSJsonSignal.yaml"
+                  - $ref: "components/success_responses/createSubscription.yaml"
         400:
           description: Invalid user input
           content:


### PR DESCRIPTION
## Summary
* Routine Change
EM-659

Note: I am still waiting on APIM support in order to preview the catalogue changes in [https://training2.nhsd.io](https://training2.nhsd.io). I am not sure how well it will render. It might be the case that I need to define the schemas and examples separately to make it easier for users to cycle through the message options.

**Update:**
It can be viewed here: https://training2.nhsd.io/developer/api-catalogue/named/dyip#post-/subscriptions If we choose this option, we should obviously tidy it up by naming the examples to make it clear which one is actually the success response and which ones are the signal formats. But leaving as is for now, as I don't imagine this is the approach we'd ultimately want to take.

As described on the ticket, this was the best stab I could do at presenting the messages that can received using our existing OAS file.

Putting this information in the subscriptions POST section seems most sensible, given those will be the users who need to know what messages are available. However, using the responses section for it is a bad pattern: naughty GPT and me!

Keeping this draft PR here as a reference, but I think ultimately the best solution would be to create a custom section in our API catalogue using Bloomreach to detail the available event messages.

## Reviews Required
* [ ] Tech Author


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
