### PR TITLE
EM-732 Add MNS change of GP signal to spec

### DIFF
--- a/specification/components/schemas/cloudevents/pdsChangeOfGpEventData.yaml
+++ b/specification/components/schemas/cloudevents/pdsChangeOfGpEventData.yaml
@@ -3,13 +3,14 @@ description: ""
 required:
 - fullUrl
 - provenance
+- registrationEncounterCode
 - versionId
-properties: 
-  versionId: 
+properties:
+  versionId:
     type: "string"
     example: 'W/"2"'
     description: "The versionId/ETAG identifies the version of the resource. The format should be a version identifier enclosed in quotes and preceded by 'W/'."
-  fullUrl: 
+  fullUrl:
     type: "string"
     example: "https://int.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient/9912003888"
     description: "The URL where the subscriber can retrieve the source of truth record for the patient or the full event payload."
@@ -43,10 +44,10 @@ properties:
         - "system"
         - "value"
         description: "Must follow this identifier system: https://fhir.nhs.uk/Id/nhsSpineASID and provide the ASID value and name of the system."
-        properties : 
-            system: 
+        properties:
+            system:
               type: "string"
               example: "https://fhir.nhs.uk/Id/nhsSpineASID"
-            value: 
+            value:
               type: "string"
               example: "477121000323"

--- a/specification/components/schemas/cloudevents/pdsChangeOfGpSignal.yaml
+++ b/specification/components/schemas/cloudevents/pdsChangeOfGpSignal.yaml
@@ -1,0 +1,133 @@
+type: "object"
+description: "The PDS Change of GP Signal. You will receive this object if you subscribe to `pds-change-of-gp-1` events with an `application/json` format."
+required:
+  - "id"
+  - "data"
+  - "type"
+  - "subject"
+  - "source"
+  - "time"
+properties:
+  id:
+    type: "string"
+    description: "UUID v4 format identifier."
+  type:
+    type: "string"
+    description: "A unique string representing the event type. For the initial private beta, only `pds-change-of-gp-1` signals can be received."
+  subject:
+    type: "object"
+    required:
+      - "nhsNumber"
+      - "familyName"
+      - "dob"
+      - "age"
+    description: "The NHS patient who is the subject of the signal."
+    properties:
+      nhsNumber:
+        type: "string"
+        description: "NHS Number validated in line with https://www.datadictionary.nhs.uk/attributes/nhs_number.html."
+      familyName:
+        type: "string"
+        description: "Last name, capitalised"
+      dob:
+        type: "string"
+        format: "date"
+        description: "ISO-8601 is the required format. However, due to data quality inconsistencies in demographic records, both 'YYYY' and 'YYYY-MM' formats may also be seen. Refer to the [PDS FHIR API documentation](https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir#get-/Patient) for further clarification on the accepted formats."
+      age:
+        type: "integer"
+        description: "The age of the patient at the time the Signal is created."
+  source:
+    type: "object"
+    required:
+      - "name"
+      - "identifier"
+    description: "Organisation responsible for publishing the patient-related signal."
+    properties:
+      name:
+        type: "string"
+        description: "Organisation name"
+      identifier:
+        type: "object"
+        required:
+          - "system"
+          - "value"
+        description: "Must follow this identifier system: https://fhir.nhs.uk/Id/nhsSpineASID and provide the ASID Code as the value."
+        properties:
+          system:
+            type: "string"
+          value:
+            type: "string"
+  time:
+    type: "string"
+    format: "date-time"
+    description: "The time at which the signal is published. This must be a compliant RFC3339 datetime in line with the FHIR standard for [system instants](https://hl7.org/fhir/R4/datatypes.html#instant). This means it can have seconds or milliseconds precision."
+  data:
+    type: "object"
+    required:
+    - fullUrl
+    - provenance
+    - registrationEncounterCode
+    - versionId
+    properties:
+      versionId:
+        type: "string"
+        description: "The versionId/ETAG identifies the version of the resource. The format should be a version identifier enclosed in quotes and preceded by 'W/'."
+      fullUrl:
+        type: "string"
+        description: "The URL where the subscriber can retrieve the source of truth record for the patient or the full event payload."
+      registrationEncounterCode:
+        type: "string"
+        description: |
+          Numeric code that represents the type of GP registration that occurred. This field is only provided for the pds-change-of-gp-1 event type.
+          The permitted codes are as follows:
+          | Code | Type               | Description                                                                                                      |
+          | ---- | ------------------ | ---------------------------------------------------------------------------------------------------------------- |
+          | 1    |  Birth             | At the time of registration, if the patient has been born in the last year then it is counted as such.           |
+          | 2    |  First Acceptance  | Very rare scenario - patient is a UK National and has never previously been registered with an NHS GP Practice.  |
+          | 3    |  Transfer In       | Accounts for the vast majority of registrations - a patient registers with a new GP Practice.                    |
+          | 4    |  Immigrant         | A patient has moved to the UK and registers with a GP Practice .                                                 |
+          | 6    |  Internal Transfer | A deprecated type. In [NHAIS](https://digital.nhs.uk/services/nhais) a transfer between two GP practices in the same NHAIS region is counted as this type within [PCRM](https://digital.nhs.uk/services/primary-care-registration-management) registrations are centralised and will be counted as Type 3 |
+      provenance: 
+        type: "object"
+        description: "The provenance describes which organisation was responsible for the creation of the event."
+        required:
+        - name
+        - identifier
+        properties:
+          name: 
+            type: "string"
+            description: "The name of the organisation responsible for the creating the event. This may be an empty string due to publisher data issues."
+          identifier: 
+            type: "object"
+            required:
+            - "system"
+            - "value"
+            description: "Must follow this identifier system: https://fhir.nhs.uk/Id/nhsSpineASID and provide the ASID value and name of the system."
+            properties:
+                system:
+                  type: "string"
+                value:
+                  type: "string"
+example:
+  id: "236a1d4a-5d69-4fa9-9c7f-e72bf505aa5b"
+  type: "pds-change-of-gp-1"
+  subject:
+    age: 6
+    dob: "2017-10-02"
+    familyName: "DAWKINS"
+    nhsNumber: "9912003888"
+  source:
+    name: "NHS DIGITAL"
+    identifier:
+      system: "https://fhir.nhs.uk/Id/nhsSpineASID"
+      value: "477121000324"
+  time: "2022-04-05T17:31:00.000Z"
+  data:
+    versionId: 'W/"2"'
+    fullUrl: "https://int.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient/9912003888"
+    registrationEncounterCode: "3"
+    provenance:
+      name: "The GP Practice"
+      identifier:
+        system: "https://fhir.nhs.uk/Id/nhsSpineASID"
+        value: "477121000323"

--- a/specification/multicast-notification-service.yaml
+++ b/specification/multicast-notification-service.yaml
@@ -224,7 +224,7 @@ paths:
                   type: object
                   description: "This field is optional, dependent on the agreements between the publishing system and the MNS team. While the data schema might vary based on the system and use-case, it is preferred to include a pointer for subscribers to access the full record when necessary for their workflow."
                   anyOf:
-                    - $ref: "components/schemas/cloudevents/pdsEventData.yaml"
+                    - $ref: "components/schemas/cloudevents/pdsChangeOfGpEventData.yaml"
             examples:
               pdsChangeOfGpEvent:
                 value:


### PR DESCRIPTION
## Summary
Add a .yaml OAS object schema for the PDS Change of GP Signal. This is to support EM-732. My plan is to link to the schema in our supplementary page. It is not actually used by our API spec, but it makes sense for it to be stored in this repo.

Additionally, tidied an existing file and moved one directory about.

## Reviews Required
* [x] Dev


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [x] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [x] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [x] I have ensured the changelog has been updated by the submitter, if necessary.
