### PR TITLE
EM-881 Action user feedback on API spec

### DIFF
--- a/specification/components/schemas/cloudevents/eventSubjectPatientExample.yaml
+++ b/specification/components/schemas/cloudevents/eventSubjectPatientExample.yaml
@@ -1,0 +1,17 @@
+description: "An NHS patient as represented in the subject property of an MNS event"
+type: "object"
+required:
+  - "nhsNumber"
+  - "familyName"
+  - "dob"
+properties:
+  nhsNumber:
+    type: "string"
+    description: "NHS Number validated in line with https://www.datadictionary.nhs.uk/attributes/nhs_number.html."
+  familyName:
+    type: "string"
+    description: "Last name, capitalised"
+  dob:
+    type: "string"
+    format: "date"
+    description: "ISO-8601 is the required format. However, due to data quality inconsistencies in demographic records, both 'YYYY' and 'YYYY-MM' formats are also acceptable. Refer to the [PDS FHIR API documentation](https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir#get-/Patient) for further clarification on the accepted formats."

--- a/specification/multicast-notification-service.yaml
+++ b/specification/multicast-notification-service.yaml
@@ -8,15 +8,15 @@ info:
     ## Overview
     ![MNS High-level Diagram](https://raw.githubusercontent.com/NHSDigital/multicast-notification-service/master/assets/images/mns-high-level-diagram.svg )
 
-    Use this API to publish events and subscribe to healthcare-related signals. This API currently only live with patient-related signals. However, it is intended to as a robust service that could support many 
-    types of future signals e.g. changes related to healthcare organisations or staff. The signals do not contain clinical information; they simply describe what type of event occured to whom/what and where. 
-    Where possible, a pointer is provided to enable retrieval of the associated payload.
+    Use this API to publish events and subscribe to healthcare-related signals. This API is currently only live with patient-related signals. However, it is intended as a robust service that could support many types of future signals e.g. changes related to healthcare organisations or staff.
+    
+    The signals do not contain clinical information; they simply describe what type of event occured to whom/what and where. Where possible, a pointer is provided to enable retrieval of the associated payload.
 
     This API is intended for NHS England internal product teams as a means of decoupling systems by providing access to streams of lightweight data from various sources without the need for direct integration.
 
     You can:
       - Publish events. The first use case is GP Registration Change events.
-      - subscribe to signals based on criteria such as the event type or patient NHS number. The team is actively building a backlog of future signal candidates, which can be viewed in our [Signal Catalogue page](TODO).
+      - Subscribe to signals based on criteria such as the event type or patient NHS number. The team is actively building a backlog of future signal candidates, which can be viewed in our [Signal Catalogue page](TODO).
 
     Data flow:
       1. An event occurs on a provider system. The provider system sends MNS the event.
@@ -194,7 +194,7 @@ paths:
                   description: "A unique string representing the event type."
                 subject:
                   type: "object"
-                  description: "The healthcare entity to which the event occurred. For example, this could be a person such as an NHS patient or staff member or an organisation.
+                  description: "The healthcare entity to which the event occurred. For example, this could be an NHS organisation or a person such as an NHS patient or member of staff.
                   We currently only have a schema for a patient as a subject but will work with you to agree a new schema if you have a different use case."
                   oneOf:
                     - $ref: "components/schemas/cloudevents/eventSubjectPatientExample.yaml"
@@ -306,7 +306,7 @@ paths:
                   id: "236a1d4a-5d69-4fa9-9c7f-e72bf505aa5b"
                   type: "possible-future-event-containing-no-data-field"
                   subject:
-                    nhsNumber: "The subject schema would be different if the subject was not a patient."
+                    nhsNumber: "A new subject schema would need to be proposed for subjects other than patients."
                     familyName: "DAWKINS"
                     dob: "2017-10-02"
                   source:
@@ -365,15 +365,15 @@ paths:
         Use this endpoint to subscribe to healthcare-related signals. You can view details of the available signals in our [Signal Catalogue page](TODO).
         
         ### Subscription filtering
-        You can filter the signals you want to receive using the `criteria` field in the payload. As a minimum, you must specify the signal type. For example, if you provide `eventType=pds-change-of-gp-1` 
-        this will mean that you receive all PDS Change of GP events. Currently the only additional filter you can use is NHS Number. We are working with subscribers during private beta to identify any other useful 
+        You can filter the signals you want to receive using the `criteria` field in the payload. As a minimum, you must specify the signal type. For example, if you provide `eventType=pds-change-of-gp-1`
+        this will mean that you receive all PDS Change of GP events. Currently the only additional filter you can use is NHS Number. We are working with subscribers during private beta to identify any other useful
         filters. There may be further filters available in future.
 
         For further information refer to the payload schema below.
 
         ### Subscription delivery
-        You can specify the endpoint you want signals delivered to using the `channel.endpoint` field in the payload. MNS currently only supports delivery to [AWS SQS](https://aws.amazon.com/sqs/) endpoints and 
-        [MESH](https://digital.nhs.uk/services/message-exchange-for-social-care-and-health-mesh) mailboxes. We are working with users during private beta to identify other potential delivery endpoints. 
+        You can specify the endpoint you want signals delivered to using the `channel.endpoint` field in the payload. MNS currently only supports delivery to [AWS SQS](https://aws.amazon.com/sqs/) endpoints and
+        [MESH](https://digital.nhs.uk/services/message-exchange-for-social-care-and-health-mesh) mailboxes. We are working with users during private beta to identify other potential delivery endpoints.
         There may be further delivery endpoints available in future.
 
         You can make suggestions using [feature upvote](https://nhs-digital-api-management.featureupvote.com).

--- a/specification/multicast-notification-service.yaml
+++ b/specification/multicast-notification-service.yaml
@@ -375,15 +375,29 @@ paths:
       description: |
         ### Overview
         Use this endpoint to subscribe to patient-related signals.
+        
+        ### Subscription filtering
+        You can filter the signals you want to receive using the `criteria` field in the payload. As a minimum, you must specify the signal type. For example, if you provide `eventType=pds-change-of-gp-1` 
+        this will mean that you receive all PDS Change of GP events. Currently the only additional filter you can use is NHS Number. We are working with subscribers during private beta to identify any other useful 
+        filters. There may be further filters available in future.
+
+        For further information refer to the payload schema below.
+
+        ### Subscription delivery
+        You can specify the endpoint you want signals delivered to using the `channel.endpoint` field in the payload. MNS currently only supports delivery to [AWS SQS](https://aws.amazon.com/sqs/) endpoints and 
+        [MESH](https://digital.nhs.uk/services/message-exchange-for-social-care-and-health-mesh) mailboxes. We are working with users during private beta to identify other potential delivery endpoints. 
+        There may be further delivery endpoints available in future.
+
+        You can make suggestions using [feature upvote](https://nhs-digital-api-management.featureupvote.com).
 
         ### Sandbox testing
         You can test the following scenarios in our sandbox environment:
 
         | Scenario                                  | Request                                                                  | Response                                                                    |
         | ----------------------------------------- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
-        | Subscribe to Events (GP Reg Changes)      | Content-Type: `application/fhir+json`                                    | HTTP Status 201 and response containing the id of the subscription created. |
+        | Subscribe to GP registration changes      | Content-Type: `application/fhir+json`                                    | HTTP Status 201 and response containing the id of the subscription created. |
         | Subscribe to NHS number changes           | Content-Type: `application/fhir+json`                                    | HTTP Status 201 and response containing the id of the subscription created. |
-        | Subscribe to PDS death notification       | Content-Type: `application/fhir+json`                                    | HTTP Status 201 and response containing the id of the subscription created. |
+        | Subscribe to PDS death notifications      | Content-Type: `application/fhir+json`                                    | HTTP Status 201 and response containing the id of the subscription created. |
         | Publish a subscription with invalid data  | E.g. modify the subscription to have an invalid value for `resourceType` | HTTP Status 400 and response containing a validation error.                 |
 
         You can try out the sandbox using the 'Try this API' feature on this page.
@@ -452,7 +466,7 @@ paths:
                       description: "The type of channel to send notifications on. Of the options within [FHIR](https://hl7.org/fhir/R4/valueset-subscription-channel-type.html), MNS currently only supports `message`."
                     endpoint:
                       type: "string"
-                      description: "The endpoint which messages will be delivered to. MNS currently only supports [MESH](https://digital.nhs.uk/services/message-exchange-for-social-care-and-health-mesh) mailbox and [AWS SQS](https://aws.amazon.com/sqs/) endpoints. Note: for MESH delivery you must provide the full mailbox ID and for SQS delivery you must provide the full SQS ARN of your desired queue."
+                      description: "The endpoint which signals will be delivered to. MNS currently only supports delivery to [MESH](https://digital.nhs.uk/services/message-exchange-for-social-care-and-health-mesh) mailboxes and [AWS SQS](https://aws.amazon.com/sqs/) endpoints. Note: for MESH delivery you must provide the full mailbox ID and for SQS delivery you must provide the full SQS ARN of your desired queue."
                     payload:
                       type: "string"
                       description: "The mime type to send the payload in. MNS currently only supports `application/json` signals but there are future plans to support other formats such as an application/fhir+json R4 Bundle."

--- a/specification/multicast-notification-service.yaml
+++ b/specification/multicast-notification-service.yaml
@@ -8,17 +8,15 @@ info:
     ## Overview
     ![MNS High-level Diagram](https://raw.githubusercontent.com/NHSDigital/multicast-notification-service/master/assets/images/mns-high-level-diagram.svg )
 
-    Use this API to publish events and subscribe to patient-related signals. The signals do not contain clinical information; they simply describe what
-    type of event occured to whom and where. Where possible, a pointer is provided to enable retrieval of the associated payload.
+    Use this API to publish events and subscribe to healthcare-related signals. This API currently only live with patient-related signals. However, it is intended to as a robust service that could support many 
+    types of future signals e.g. changes related to healthcare organisations or staff. The signals do not contain clinical information; they simply describe what type of event occured to whom/what and where. 
+    Where possible, a pointer is provided to enable retrieval of the associated payload.
 
     This API is intended for NHS England internal product teams as a means of decoupling systems by providing access to streams of lightweight data from various sources without the need for direct integration.
 
     You can:
-      - Publish events. The first planned use case is GP Registration Change events. The team is actively building a backlog of future event candidates, for example:
-        PDS record changes, vaccinations.
-
-    In future, you will be able to:
-      - subscribe to signals based on certain criteria such as the event type
+      - Publish events. The first use case is GP Registration Change events.
+      - subscribe to signals based on criteria such as the event type or patient NHS number. The team is actively building a backlog of future signal candidates, which can be viewed in our [Signal Catalogue page](TODO).
 
     Data flow:
       1. An event occurs on a provider system. The provider system sends MNS the event.
@@ -32,7 +30,7 @@ info:
 
     Note: during beta, this API will only be used by NHS England product teams with a valid use case.
     ## Related APIs
-    The following API also provides access to patient-related events:
+    The following API also provides access to healthcare-related events:
       - [National Events Management Service - FHIR API](https://digital.nhs.uk/developer/api-catalogue/national-events-management-service-fhir "National
       Events Management Service - FHIR API") - the difference is that the payloads MNS delivers will be event signals: lightweight events that do not contain any clinical information, they 'signal' a state has changed. NEMS delivers events to external subscriber systems whereas MNS is intended only for use by internal NHS England product teams. The two systems will be complementary.
     ## API status and roadmap
@@ -135,12 +133,12 @@ paths:
       summary: "Publish an event"
       description: |
         ### Overview
-        Use this endpoint to publish a patient-related event.
+        Use this endpoint to publish a healthcare-related event.
 
         The event contains only a minimum dataset based on the recommendations of the [CloudEvents specification](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md).
 
         ### Data and Metadata:
-          - Metadata: In the context of an event, metadata refers to the additional information that describes the event and provides context about it. It includes elements such as the family name and date of birth which are primarily for verification. Users must be cautious not to use such metadata to modify a patient's demographic details. Instead, if updates are necessary, users should conduct a full PDS retrieval to ensure accuracy and completeness in their workflows.
+          - Metadata: In the context of an event, metadata refers to the additional information that describes the event and provides context about it. For example, for [PDS](https://digital.nhs.uk/services/personal-demographics-service) events it includes elements such as the family name and date of birth which are primarily for verification. Users must be cautious not to use such metadata to modify a patient's demographic details. Instead, if updates are necessary, users should conduct a full PDS retrieval to ensure accuracy and completeness in their workflows.
           - Data: The inclusion of the data field might vary. Its presence is subject to agreements between the MNS team and the originating system. While the structure of the data might differ across various systems and scenarios, it's a general preference to have a pointer included. This pointer aids subscribers in accessing the entire record when necessary for their workflow.   
 
         ### Sandbox testing
@@ -148,7 +146,9 @@ paths:
 
         | Scenario                                  | Request                                                                 | Response                                                       |
         | ----------------------------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------- |
-        | Publish an MDS Event (GP Reg Change)      | Content-Type: `application/json` Event Type: `pds-change-of-gp-1`       | HTTP Status 200 and response containing id and success status. |
+        | Publish a GP Registration Change event    | Content-Type: `application/json` Event Type: `pds-change-of-gp-1`       | HTTP Status 200 and response containing id and success status. |
+        | Publish a GP Death event                  | Content-Type: `application/json` Event Type: `pds-death-notification-1` | HTTP Status 200 and response containing id and success status. |
+        | Publish an NHS Number Change event        | Content-Type: `application/json` Event Type: `nhs-number-change-1`      | HTTP Status 200 and response containing id and success status. |
         | Publish an event with invalid data        | E.g. an event with an invalid value for `time`                          | HTTP Status 400 and response containing a validation error.    |
 
         You can try out the sandbox using the 'Try this API' feature on this page.
@@ -194,28 +194,16 @@ paths:
                   description: "A unique string representing the event type."
                 subject:
                   type: "object"
-                  required:
-                    - "nhsNumber"
-                    - "familyName"
-                    - "dob"
-                  description: "The NHS patient to whom the event occurred."
-                  properties:
-                    nhsNumber:
-                      type: "string"
-                      description: "NHS Number validated in line with https://www.datadictionary.nhs.uk/attributes/nhs_number.html."
-                    familyName:
-                      type: "string"
-                      description: "Last name, capitalised"
-                    dob:
-                      type: "string"
-                      format: "date"
-                      description: "ISO-8601 is the required format. However, due to data quality inconsistencies in demographic records, both 'YYYY' and 'YYYY-MM' formats are also acceptable. Refer to the [PDS FHIR API documentation](https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir#get-/Patient) for further clarification on the accepted formats."
+                  description: "The healthcare entity to which the event occurred. For example, this could be a person such as an NHS patient or staff member or an organisation.
+                  We currently only have a schema for a patient as a subject but will work with you to agree a new schema if you have a different use case."
+                  oneOf:
+                    - $ref: "components/schemas/cloudevents/eventSubjectPatientExample.yaml"
                 source:
                   type: "object"
                   required:
                     - "name"
                     - "identifier"
-                  description: "Organisation responsible for publishing the patient-related event."
+                  description: "Organisation responsible for publishing the event."
                   properties:
                     name:
                       type: "string"
@@ -316,9 +304,9 @@ paths:
               mnsEventMetaDataOnly:
                 value:
                   id: "236a1d4a-5d69-4fa9-9c7f-e72bf505aa5b"
-                  type: "possible-future-event-type-no-data-field"
+                  type: "possible-future-event-containing-no-data-field"
                   subject:
-                    nhsNumber: "9912003888"
+                    nhsNumber: "The subject schema would be different if the subject was not a patient."
                     familyName: "DAWKINS"
                     dob: "2017-10-02"
                   source:
@@ -374,7 +362,7 @@ paths:
       summary: "Subscribe to events"
       description: |
         ### Overview
-        Use this endpoint to subscribe to patient-related signals.
+        Use this endpoint to subscribe to healthcare-related signals. You can view details of the available signals in our [Signal Catalogue page](TODO).
         
         ### Subscription filtering
         You can filter the signals you want to receive using the `criteria` field in the payload. As a minimum, you must specify the signal type. For example, if you provide `eventType=pds-change-of-gp-1` 


### PR DESCRIPTION
## Summary
* Routine Change

**NOTE:** PR not yet ready for review. We need our signal catalogue to be published so we can link to it from the spec. Currently waiting for our request to be actioned by the APIM team.

This PR addresses the following comments from users:

- It is not clear what the full list of Signals are and what status they are in.
- The rules around subscription filters is hidden away in the schema - could be made clearer. (I also decided, based on this feedback, that we should also make the available subscription delivery mechanisms clearer).
- Confused about whether other events are permitted besides patient-related ones. Our spec only refers to these types of events. As I understood it, our service is agnostic and could support other types of events e.g. NHS staff or org changes, so we should update our spec to reflect that.

Additional changes:
- Housekeeping. Updated the list of events you can publish in sandbox scenarios.
- Top level description was horrendously out of date. Updated.
- **Pending** updated diagram.

## Reviews Required
* [x] Dev


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
