### PR TITLE
EM-700 subscription get all pagination

### DIFF
--- a/sandbox/app.spec.js
+++ b/sandbox/app.spec.js
@@ -141,7 +141,15 @@ describe("app handler tests", function () {
         it("responds with a success when user requests to get ALL subscriptions", (done) => {
             request(server)
                 .get("/subscriptions")
-                .expect(200, [mockSubscriptions.mockCreatedSubscription], done);
+                .expect(200, {  "resourceType": "Bundle",
+                                "type": "searchset",
+                                "link": [
+                                    {
+                                        "relation": "self",
+                                        "url": "/subscriptions"
+                                    }
+                                ], "entry": [mockSubscriptions.mockCreatedSubscription]
+                            }, done);
         });
     });
 });

--- a/sandbox/handlers.js
+++ b/sandbox/handlers.js
@@ -139,8 +139,16 @@ async function getSubscriptions(req, res, next) {
             headers: req.rawHeaders,
         }
     });
-
-    res.json([mockSubscriptions.mockCreatedSubscription])
+    res.json({"resourceType": "Bundle",
+        "type": "searchset",
+        "link": [
+            {
+                "relation": "self",
+                "url": "/subscriptions"
+            }
+        ],
+        "entry": [mockSubscriptions.mockCreatedSubscription]}
+        )
     res.end();
     next();
 }

--- a/specification/multicast-notification-service.yaml
+++ b/specification/multicast-notification-service.yaml
@@ -575,6 +575,7 @@ paths:
         ### Overview
         Use this endpoint to retrieve a list of all subscriptions belonging to you.
         If your application does not own any subscriptions, then this endpoint will return an empty list.
+        The list of subscriptions is presented in a FHIR resource bundle, allowing pagination. 
         ### Sandbox testing
         You can test the following scenarios in our sandbox environment:
         | Scenario                                  | Request                                                                  | Response                                                                    |
@@ -602,15 +603,42 @@ paths:
           schema:
             type: string
             example: 11C46F5F-CDEF-4865-94B2-0EE0EDCC26DA
+        - name: continue_from
+          in: query
+          required: false
+          description: |-
+            An optional query string parameter used for pagination, specifying the point from which to continue the list.
+          schema:
+            type: string
       responses:
         200:
           description: Successfully retrieved list of subscriptions
           content:
             application/fhir+json:
               schema:
-                type: array
-                items:
-                  $ref: "components/schemas/fhir/R4/Subscription.yaml"
+                type: object
+                properties:
+                  resourceType:
+                    type: string
+                    enum: [Bundle]
+                  type:
+                    type: string
+                    enum: [searchset]
+                  link:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        relation:
+                          type: string
+                          description: Relation type, e.g., 'self', 'next'. The 'next' relation is present only if there's additional content to paginate through.
+                        url:
+                          type: string
+                          description: The URL for the relation. For 'next', this URL points to the next page of results.
+                  entry:
+                    type: array
+                    items:
+                      $ref: "components/schemas/fhir/R4/Subscription.yaml"
         401:
           $ref: "components/errors/unauthenticated-error.yaml"
         403:

--- a/specification/multicast-notification-service.yaml
+++ b/specification/multicast-notification-service.yaml
@@ -635,6 +635,9 @@ paths:
                         url:
                           type: string
                           description: The URL for the relation. For 'next', this URL points to the next page of results.
+                      example:
+                        relation: next
+                        url: '/subscriptions?continue_from=ZmRqa2xmZGprc2xmamtsZHNqZmxkc2Zkcw=='
                   entry:
                     type: array
                     items:

--- a/specification/multicast-notification-service.yaml
+++ b/specification/multicast-notification-service.yaml
@@ -639,6 +639,17 @@ paths:
                     type: array
                     items:
                       $ref: "components/schemas/fhir/R4/Subscription.yaml"
+        400:
+          description: Invalid user input
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: string
+                    description: Error string that explains the problem
+                    example: The continue_from field was not valid
         401:
           $ref: "components/errors/unauthenticated-error.yaml"
         403:


### PR DESCRIPTION
## Summary
* :sparkles: New Feature

The subscriptions get all endpoint has been changed to return a different format response - a fhir bundle rather than a list. it can now return 400 - bad request responses. Also the request can now optionally take a querystring of "continue_from" - used for paging.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
