### PR TITLE
mns-2422: fix: update examples in subscription criteria for consistency

### DIFF
--- a/specification/requestBody/create-or-update-subscription-body.yaml
+++ b/specification/requestBody/create-or-update-subscription-body.yaml
@@ -39,7 +39,7 @@ content:
             Criteria for the subscription. A valid criteria must contain a permitted value for `eventType`.
             Additional criteria depends on the event and is documented on our
             [Event Catalogue page](https://digital.nhs.uk/developer/api-catalogue/Taxonomies/publish-subscribe-events).
-            Examples: 'eventType="gpreg-change-gp-req-1"' or 'eventType="gpreg-change-gp-req-1" AND generalpractitioner="XY11"'
+            Examples: `eventType='gpreg-change-gp-req-1'`` or `eventType='gpreg-change-gp-req-1' AND generalpractitioner='XY11'`
           # Separate examples are only supported in OpenAPI 3.1
           example: "eventType='gpreg-change-gp-req-1' AND generalpractitioner='XY11'"
         channel:

--- a/specification/requestBody/create-or-update-subscription-body.yaml
+++ b/specification/requestBody/create-or-update-subscription-body.yaml
@@ -39,7 +39,7 @@ content:
             Criteria for the subscription. A valid criteria must contain a permitted value for `eventType`.
             Additional criteria depends on the event and is documented on our
             [Event Catalogue page](https://digital.nhs.uk/developer/api-catalogue/Taxonomies/publish-subscribe-events).
-            Examples: `eventType='gpreg-change-gp-req-1'`` or `eventType='gpreg-change-gp-req-1' AND generalpractitioner='XY11'`
+            Examples: `eventType='gpreg-change-gp-req-1'` or `eventType='gpreg-change-gp-req-1' AND generalpractitioner='XY11'`
           # Separate examples are only supported in OpenAPI 3.1
           example: "eventType='gpreg-change-gp-req-1' AND generalpractitioner='XY11'"
         channel:

--- a/specification/requestBody/create-or-update-subscription-body.yaml
+++ b/specification/requestBody/create-or-update-subscription-body.yaml
@@ -39,9 +39,9 @@ content:
             Criteria for the subscription. A valid criteria must contain a permitted value for `eventType`.
             Additional criteria depends on the event and is documented on our
             [Event Catalogue page](https://digital.nhs.uk/developer/api-catalogue/Taxonomies/publish-subscribe-events).
-            Examples: 'eventType=gpreg-change-gp-req-1' or 'eventType=gpreg-change-gp-req-1 AND generalpractitioner=XY11'
+            Examples: 'eventType="gpreg-change-gp-req-1"' or 'eventType="gpreg-change-gp-req-1" AND generalpractitioner="XY11"'
           # Separate examples are only supported in OpenAPI 3.1
-          example: "eventType=gpreg-change-gp-req-1 AND generalpractitioner=XY11"
+          example: "eventType='gpreg-change-gp-req-1' AND generalpractitioner='XY11'"
         channel:
           type: "object"
           required:


### PR DESCRIPTION
## Summary
* Routine Change

Small tweak to subscription docs to show that you need to quote your strings in criteria


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [x] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [x] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [x] I have ensured the changelog has been updated by the submitter, if necessary.
